### PR TITLE
Implement dynamic loading of Rouge

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,16 +1,16 @@
 source 'https://rubygems.org'
 
-gem 'rouge'
-
 # Framework
 gem 'sinatra',  '~>2.0'
 
 # Asset pipeline
+gem 'sassc', '~>2.0'
 gem 'sprockets', '~>4.0'
 gem 'uglifier', '~>4.0'
-gem 'sassc', '~>2.0'
 
-# Testing
-gem 'rake'
-gem 'minitest'
-gem 'm'
+# Development and testing
+group :development do
+  gem 'm', '~>1.0'
+  gem 'minitest', '~> 5.0'
+  gem 'rake', '~> 13.0'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -9,3 +9,8 @@ gem 'sinatra',  '~>2.0'
 gem 'sprockets', '~>4.0'
 gem 'uglifier', '~>4.0'
 gem 'sassc', '~>2.0'
+
+# Testing
+gem 'rake'
+gem 'minitest'
+gem 'm'

--- a/Gemfile
+++ b/Gemfile
@@ -12,5 +12,4 @@ gem 'uglifier', '~>4.0'
 group :development do
   gem 'm', '~>1.0'
   gem 'minitest', '~> 5.0'
-  gem 'rake', '~> 13.0'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -12,4 +12,5 @@ gem 'uglifier', '~>4.0'
 group :development do
   gem 'm', '~>1.0'
   gem 'minitest', '~> 5.0'
+  gem 'rake', '~> 13.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,7 +36,6 @@ PLATFORMS
 DEPENDENCIES
   m (~> 1.0)
   minitest (~> 5.0)
-  rake (~> 13.0)
   sassc (~> 2.0)
   sinatra (~> 2.0)
   sprockets (~> 4.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,6 +36,7 @@ PLATFORMS
 DEPENDENCIES
   m (~> 1.0)
   minitest (~> 5.0)
+  rake (~> 13.0)
   sassc (~> 2.0)
   sinatra (~> 2.0)
   sprockets (~> 4.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,7 +15,6 @@ GEM
     rack-protection (2.0.8.1)
       rack
     rake (13.0.1)
-    rouge (3.15.0)
     ruby2_keywords (0.0.2)
     sassc (2.2.1)
       ffi (~> 1.9)
@@ -35,14 +34,13 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  m
-  minitest
-  rake
-  rouge
+  m (~> 1.0)
+  minitest (~> 5.0)
+  rake (~> 13.0)
   sassc (~> 2.0)
   sinatra (~> 2.0)
   sprockets (~> 4.0)
   uglifier (~> 4.0)
 
 BUNDLED WITH
-   2.1.2
+   2.1.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,11 +4,17 @@ GEM
     concurrent-ruby (1.1.5)
     execjs (2.7.0)
     ffi (1.12.1)
+    m (1.5.1)
+      method_source (>= 0.6.7)
+      rake (>= 0.9.2.2)
+    method_source (0.9.2)
+    minitest (5.14.0)
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
     rack (2.1.1)
     rack-protection (2.0.8.1)
       rack
+    rake (13.0.1)
     rouge (3.15.0)
     ruby2_keywords (0.0.2)
     sassc (2.2.1)
@@ -29,6 +35,9 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  m
+  minitest
+  rake
   rouge
   sassc (~> 2.0)
   sinatra (~> 2.0)

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,10 @@
+require "bundler/setup"
+require "rake/testtask"
+
+Rake::TestTask.new do |t|
+    ENV["APP_ENV"] = "test"
+      t.test_files = FileList["test/**/*_test.rb"]
+end
+desc "Run tests"
+
+task default: :test

--- a/app.rb
+++ b/app.rb
@@ -5,67 +5,11 @@ require 'sinatra/base'
 require 'sprockets'
 require 'uglifier'
 
+require_relative 'lib/demo'
+require_relative 'lib/message'
+
 require_relative 'lib/loader'
-
 Loader.get :latest
-
-class Demo
-  attr_reader :rouge, :lexer, :source
-
-  def initialize(ver = :latest, lang = nil, source = nil)
-    @rouge = set_version ver
-    @lexer = set_lexer lang
-    @source = set_source source
-  end
-
-  def all_lexers
-    rouge::Lexer.all.sort_by(&:tag)
-  end
-
-  def lexer_count
-    all_lexers.count
-  end
-
-  def result
-    rouge.highlight source, lexer, 'html'
-  end
-
-  def version
-    rouge.version
-  end
-
-  private def set_version(ver)
-    ver = (ver.is_a?(String) && ver[0] == "v") ? ver.slice(1..-1) : :latest
-
-    Loader.get ver
-  end
-
-  private def set_lexer(lang)
-    return all_lexers.sample if lang.nil?
-
-    rouge::Lexer.find(lang) || all_lexers.sample
-  end
-
-  private def set_source(source)
-    source || lexer.demo
-  end
-end
-
-class Message
-  MSG = {}
-
-  MSG[400] =
-    "<strong>Bad Input</strong>: The input that you submitted is invalid. Please
-    correct it and try again."
-
-  MSG[413] =
-    "<strong>Too Long</strong>: This form accepts a maximum of 1500 characters of text.
-    Please reduce the amount of text and try again."
-
-  def self.[](k)
-    MSG[k]
-  end
-end
 
 class Dingus < Sinatra::Base
   enable :sessions

--- a/app.rb
+++ b/app.rb
@@ -7,6 +7,8 @@ require 'uglifier'
 
 require_relative 'lib/loader'
 
+Loader.get :latest
+
 class Demo
   attr_reader :rouge, :lexer, :source
 

--- a/app.rb
+++ b/app.rb
@@ -1,21 +1,23 @@
 require 'base64'
 require 'json'
-require 'rouge'
 require 'sassc'
 require 'sinatra/base'
 require 'sprockets'
 require 'uglifier'
 
+require_relative 'lib/loader'
+
 class Demo
-  attr_reader :lexer, :source
+  attr_reader :rouge, :lexer, :source
 
   def initialize(lang = nil, source = nil)
+    @rouge = Loader.get :latest
     @lexer = set_lexer lang
     @source = set_source source
   end
 
   def all_lexers
-    Rouge::Lexer.all.sort_by(&:tag)
+    rouge::Lexer.all.sort_by(&:tag)
   end
 
   def lexer_count
@@ -23,17 +25,17 @@ class Demo
   end
 
   def result
-    Rouge.highlight source, lexer, 'html'
+    rouge.highlight source, lexer, 'html'
   end
 
   def version
-    Rouge.version
+    rouge.version
   end
 
   private def set_lexer(lang)
     return all_lexers.sample if lang.nil?
 
-    Rouge::Lexer.find(lang) || all_lexers.sample
+    rouge::Lexer.find(lang) || all_lexers.sample
   end
 
   private def set_source(source)

--- a/assets/javascripts/application.js
+++ b/assets/javascripts/application.js
@@ -1,4 +1,8 @@
 // Define error messages
+const error_message_input =
+  `<strong>Bad Input</strong>: The input that you submitted is invalid. Please
+  correct it and try again.`
+
 const error_message_length =
   `<strong>Too Long</strong>: This form accepts a maximum of 1500 characters of text.
   Please reduce the amount of text and try again.`
@@ -10,6 +14,7 @@ const error_message_server =
 const flash  = document.getElementById("flash_message");
 const lang   = document.getElementById("parse_language");
 const source = document.getElementById("parse_source");
+const ver    = document.getElementById("parse_version");
 const result = document.getElementById("parse_result");
 const save   = document.getElementById("save_button");
 const tip    = document.getElementById("save_message");
@@ -34,6 +39,9 @@ const update = function(endpoint, payload) {
       source.value = data.source;
       result.innerHTML = "<code>" + data.result + "</code>";
       flash.style.display = "none";
+    } else if (request.readyState === XMLHttpRequest.DONE && request.status === 400) {
+      flash.innerHTML = error_message_input
+      flash.style.display = "block";
     } else if (request.readyState === XMLHttpRequest.DONE && request.status === 413) {
       flash.innerHTML = error_message_length;
       flash.style.display = "block";
@@ -48,14 +56,18 @@ const update = function(endpoint, payload) {
 
 // Reset on language change
 lang.addEventListener("change", function(e) {
-  submit("/parse", { lang: lang.value });
-  history.pushState({}, "", "/" + encodeURIComponent(lang.value) + "/");
+  submit("/parse", { ver: ver.value, lang: lang.value });
+  history.pushState({}, "", "/" + encodeURIComponent(ver.value) +
+                            "/" + encodeURIComponent(lang.value) +
+                            "/");
 });
 
 // Update on source change
 source.addEventListener("input", function(e) {
-  submit("/parse", { lang: lang.value, source: source.value });
-  let draft_path = "/" + encodeURIComponent(lang.value) + "/draft";
+  submit("/parse", { ver: ver.value, lang: lang.value, source: source.value });
+  let draft_path = "/" + encodeURIComponent(ver.value) +
+                   "/" + encodeURIComponent(lang.value) +
+                   "/draft";
   if (window.location.pathname !== draft_path) {
     history.pushState({}, "", draft_path);
   }
@@ -91,7 +103,9 @@ const copyToClipboard = function(text) {
 // Save the snippet
 save.addEventListener("click", function(e) {
   e.preventDefault();
-  let save_path = "/" + encodeURIComponent(lang.value) + "/" + utoa(source.value);
+  let save_path = "/" + encodeURIComponent(ver.value) +
+                  "/" + encodeURIComponent(lang.value) +
+                  "/" + utoa(source.value);
   history.pushState({}, "", save_path);
   copyToClipboard(window.location);
   tip.innerHTML = "Link to snippet copied!";

--- a/assets/javascripts/application.js
+++ b/assets/javascripts/application.js
@@ -26,12 +26,12 @@ const update = function(endpoint, payload) {
       const data = JSON.parse(request.responseText);
       source.value = data.source;
       result.innerHTML = "<code>" + data.result + "</code>";
-      flash.style.display = "none";
+      flash.classList.remove("show");
       flash.innerHTML = "";
     } else if (request.readyState === XMLHttpRequest.DONE && request.status !== 200) {
       const data = JSON.parse(request.responseText);
       flash.innerHTML = data.message;
-      flash.style.display = "block";
+      flash.classList.add("show");
     }
   };
 

--- a/assets/javascripts/application.js
+++ b/assets/javascripts/application.js
@@ -1,15 +1,3 @@
-// Define error messages
-const error_message_input =
-  `<strong>Bad Input</strong>: The input that you submitted is invalid. Please
-  correct it and try again.`
-
-const error_message_length =
-  `<strong>Too Long</strong>: This form accepts a maximum of 1500 characters of text.
-  Please reduce the amount of text and try again.`
-
-const error_message_server =
-  `<strong>Server Error</strong>: A server error occurred while processing your input.`
-
 // Define elements
 const flash  = document.getElementById("flash_message");
 const lang   = document.getElementById("parse_language");
@@ -39,14 +27,10 @@ const update = function(endpoint, payload) {
       source.value = data.source;
       result.innerHTML = "<code>" + data.result + "</code>";
       flash.style.display = "none";
-    } else if (request.readyState === XMLHttpRequest.DONE && request.status === 400) {
-      flash.innerHTML = error_message_input
-      flash.style.display = "block";
-    } else if (request.readyState === XMLHttpRequest.DONE && request.status === 413) {
-      flash.innerHTML = error_message_length;
-      flash.style.display = "block";
-    } else if (request.readyState === XMLHttpRequest.DONE && request.status === 500) {
-      flash.innerHTML = error_message_server;
+      flash.innerHTML = "";
+    } else if (request.readyState === XMLHttpRequest.DONE && request.status !== 200) {
+      const data = JSON.parse(request.responseText);
+      flash.innerHTML = data.message;
       flash.style.display = "block";
     }
   };

--- a/assets/stylesheets/application.scss
+++ b/assets/stylesheets/application.scss
@@ -82,6 +82,10 @@ main {
         display: none;
         margin-bottom: 2.5em;
         padding: 1em;
+
+        &.show {
+          display: block;
+        }
     }
 
     section.demo {

--- a/lib/demo.rb
+++ b/lib/demo.rb
@@ -1,0 +1,41 @@
+class Demo
+  attr_reader :rouge, :lexer, :source
+
+  def initialize(ver = :latest, lang = nil, source = nil)
+    @rouge = set_version ver
+    @lexer = set_lexer lang
+    @source = set_source source
+  end
+
+  def all_lexers
+    rouge::Lexer.all.sort_by(&:tag)
+  end
+
+  def lexer_count
+    all_lexers.count
+  end
+
+  def result
+    rouge.highlight source, lexer, 'html'
+  end
+
+  def version
+    rouge.version
+  end
+
+  private def set_version(ver)
+    ver = (ver.is_a?(String) && ver[0] == "v") ? ver.slice(1..-1) : :latest
+
+    Loader.get ver
+  end
+
+  private def set_lexer(lang)
+    return all_lexers.sample if lang.nil?
+
+    rouge::Lexer.find(lang) || all_lexers.sample
+  end
+
+  private def set_source(source)
+    source || lexer.demo
+  end
+end

--- a/lib/loader.rb
+++ b/lib/loader.rb
@@ -8,58 +8,58 @@ class Loader
 
   Bundler.mkdir_p TMP_DIR
 
-  def self.available?(id)
-    return false if id < "1.1.0"
-    versions.include? id
+  def self.available?(ver)
+    return false if ver < "1.1.0"
+    versions.include? ver
   end
 
   def self.cache
     @cache ||= {}
   end
 
-  def self.dir(id)
-    File.join TMP_DIR, id
+  def self.dir(ver)
+    File.join TMP_DIR, ver
   end
 
-  def self.dir?(id)
-    Dir.exist? dir(id)
+  def self.dir?(ver)
+    Dir.exist? dir(ver)
   end
 
-  def self.fetch(id)
+  def self.fetch(ver)
     Dir.chdir(TMP_DIR) do
-      %x(gem fetch rouge -v #{id})
-      %x(gem unpack rouge-#{id}.gem)
-      File.delete "rouge-#{id}.gem"
+      %x(gem fetch rouge -v #{ver})
+      %x(gem unpack rouge-#{ver}.gem)
+      File.delete "rouge-#{ver}.gem"
     end
   end
 
-  def self.get(id)
-    id = latest if id == :latest
-    cache[id] ||= load(id)
+  def self.get(ver)
+    ver = latest if ver == :latest
+    cache[ver] ||= load(ver)
   end
 
   def self.latest
     versions.first
   end
 
-  def self.load(id)
-    raise UnavailableVersion unless available?(id)
+  def self.load(ver)
+    raise UnavailableVersion unless available?(ver)
 
-    fetch id unless dir?(id)
+    fetch ver unless dir?(ver)
 
     MUTEX.synchronize do
       Object.send(:remove_const, :Rouge) rescue NameError
-      load_silently id
+      load_silently ver
       patch_load Rouge
       Rouge.const_set(:Rouge, Rouge)
       Object.send(:remove_const, :Rouge)
     end
   end
 
-  def self.load_silently(id)
+  def self.load_silently(ver)
     old_verbose = $VERBOSE
     $VERBOSE = nil
-    Kernel.load(File.join(TMP_DIR, "rouge-#{id}", "lib/rouge.rb"))
+    Kernel.load(File.join(TMP_DIR, "rouge-#{ver}", "lib/rouge.rb"))
     $VERBOSE = old_verbose
   end
 

--- a/lib/loader.rb
+++ b/lib/loader.rb
@@ -58,12 +58,12 @@ class Loader
       #
       # The `rescue`s are for the cases where the lexer isn't defined in the current
       # version.
+      Rouge::Lexers::Gherkin.builtins rescue nil
       Rouge::Lexers::Lua.builtins rescue nil
+      Rouge::Lexers::Mathematica.builtins rescue nil
+      Rouge::Lexers::Matlab.builtins rescue nil
       Rouge::Lexers::PHP.builtins rescue nil
       Rouge::Lexers::VimL.keywords rescue nil
-      Rouge::Lexers::Gherkin.builtins rescue nil
-      Rouge::Lexers::Matlab.builtins rescue nil
-      Rouge::Lexers::Mathematica.builtins rescue nil
 
       Rouge.const_set(:Rouge, Rouge)
       Object.send(:remove_const, :Rouge)

--- a/lib/loader.rb
+++ b/lib/loader.rb
@@ -34,6 +34,7 @@ class Loader
   end
 
   def self.get(id)
+    id = latest if id == :latest
     cache[id] ||= load(id)
   end
 
@@ -42,8 +43,6 @@ class Loader
   end
 
   def self.load(id)
-    id = latest if id == :latest
-
     raise UnavailableVersion unless available?(id)
 
     fetch id unless dir?(id)
@@ -65,7 +64,7 @@ class Loader
 
   def self.versions
     path = File.join TMP_DIR, "available_versions"
-    if File.exist?(path) && (Time.now - File.mtime(path) <= 86400)
+    if File.exist?(path) && (Time.now - File.mtime(path) < 86400)
       version_nums = (defined? @versions) ? @versions : File.readlines(path, chomp: true)
     else
       response = %x(gem query --versions --all -r -e rouge)

--- a/lib/loader.rb
+++ b/lib/loader.rb
@@ -50,21 +50,7 @@ class Loader
     MUTEX.synchronize do
       Object.send(:remove_const, :Rouge) rescue NameError
       load_silently id
-
-      # These need to be preloaded while the correct `Rouge` is in the global scope,
-      # because they assume the existence of a global `Rouge` object. In the future
-      # we'll handle these differently (i.e. with a yaml file, like the Apache lexer),
-      # so it won't be necessary to add to this list.
-      #
-      # The `rescue`s are for the cases where the lexer isn't defined in the current
-      # version.
-      Rouge::Lexers::Gherkin.builtins rescue nil
-      Rouge::Lexers::Lua.builtins rescue nil
-      Rouge::Lexers::Mathematica.builtins rescue nil
-      Rouge::Lexers::Matlab.builtins rescue nil
-      Rouge::Lexers::PHP.builtins rescue nil
-      Rouge::Lexers::VimL.keywords rescue nil
-
+      patch_load Rouge
       Rouge.const_set(:Rouge, Rouge)
       Object.send(:remove_const, :Rouge)
     end
@@ -75,6 +61,16 @@ class Loader
     $VERBOSE = nil
     Kernel.load(File.join(TMP_DIR, "rouge-#{id}", "lib/rouge.rb"))
     $VERBOSE = old_verbose
+  end
+
+  def self.patch_load(rouge)
+    rouge::Lexer.define_singleton_method(:load) do |filename|
+      Loader::MUTEX.synchronize do
+        Object.const_set(:Rouge, rouge)
+        super filename
+        Object.send(:remove_const, :Rouge)
+      end
+    end
   end
 
   def self.versions

--- a/lib/loader.rb
+++ b/lib/loader.rb
@@ -1,0 +1,72 @@
+require "thread"
+
+class Loader
+  class UnavailableVersion < StandardError; end
+
+  MUTEX = Mutex.new
+  TMP_DIR = ENV["ROUGE_VER_DIR"] || File.join(Bundler.root, "tmp", "rouge")
+
+  Bundler.mkdir_p TMP_DIR
+
+  def self.available?(id)
+    return false if id < "1.1.0"
+    listing.include? id
+  end
+
+  def self.cache
+    @cache ||= {}
+  end
+
+  def self.dir(id)
+    File.join TMP_DIR, id
+  end
+
+  def self.dir?(id)
+    Dir.exist? dir(id)
+  end
+
+  def self.fetch(id)
+    Dir.chdir(TMP_DIR) do
+      %x(gem fetch rouge -v #{id})
+      %x(gem unpack rouge-#{id}.gem)
+      File.delete "rouge-#{id}.gem"
+    end
+  end
+
+  def self.listing
+    path = File.join TMP_DIR, "available_versions"
+    if File.exist?(path) && (Time.now - File.mtime(path) <= 86400)
+      version_nums = (defined? @listing) ? @listing : File.readlines(path, chomp: true)
+    else
+      response = %x(gem query --versions --all -r -e rouge)
+      version_nums = response.scan(/\d+\.\d+\.\d+/)
+      File.write path, version_nums.join("\n")
+    end
+
+    @listing = version_nums
+  end
+
+  def self.load(id)
+    raise UnavailableVersion unless available?(id)
+
+    fetch id unless dir?(id)
+
+    MUTEX.synchronize do
+      Object.send(:remove_const, :Rouge) rescue NameError
+      load_silently id
+      Rouge.const_set(:Rouge, Rouge)
+      Object.send(:remove_const, :Rouge)
+    end
+  end
+
+  def self.load_silently(id)
+    old_verbose = $VERBOSE
+    $VERBOSE = nil
+    Kernel.load(File.join(TMP_DIR, "rouge-#{id}", "lib/rouge.rb"))
+    $VERBOSE = old_verbose
+  end
+
+  def self.version(id)
+    cache[id] ||= load(id)
+  end
+end

--- a/lib/loader.rb
+++ b/lib/loader.rb
@@ -10,7 +10,7 @@ class Loader
 
   def self.available?(id)
     return false if id < "1.1.0"
-    listing.include? id
+    versions.include? id
   end
 
   def self.cache
@@ -33,25 +33,16 @@ class Loader
     end
   end
 
-  def self.latest
-    listing.first
+  def self.get(id)
+    cache[id] ||= load(id)
   end
 
-  def self.listing
-    path = File.join TMP_DIR, "available_versions"
-    if File.exist?(path) && (Time.now - File.mtime(path) <= 86400)
-      version_nums = (defined? @listing) ? @listing : File.readlines(path, chomp: true)
-    else
-      response = %x(gem query --versions --all -r -e rouge)
-      version_nums = response.scan(/\d+\.\d+\.\d+/)
-      File.write path, version_nums.join("\n")
-    end
-
-    @listing = version_nums
+  def self.latest
+    versions.first
   end
 
   def self.load(id)
-    id = latest if id.nil?
+    id = latest if id == :latest
 
     raise UnavailableVersion unless available?(id)
 
@@ -72,7 +63,16 @@ class Loader
     $VERBOSE = old_verbose
   end
 
-  def self.version(id = nil)
-    cache[id] ||= load(id)
+  def self.versions
+    path = File.join TMP_DIR, "available_versions"
+    if File.exist?(path) && (Time.now - File.mtime(path) <= 86400)
+      version_nums = (defined? @versions) ? @versions : File.readlines(path, chomp: true)
+    else
+      response = %x(gem query --versions --all -r -e rouge)
+      version_nums = response.scan(/\d+\.\d+\.\d+/)
+      File.write path, version_nums.join("\n")
+    end
+
+    @versions = version_nums
   end
 end

--- a/lib/loader.rb
+++ b/lib/loader.rb
@@ -50,6 +50,21 @@ class Loader
     MUTEX.synchronize do
       Object.send(:remove_const, :Rouge) rescue NameError
       load_silently id
+
+      # These need to be preloaded while the correct `Rouge` is in the global scope,
+      # because they assume the existence of a global `Rouge` object. In the future
+      # we'll handle these differently (i.e. with a yaml file, like the Apache lexer),
+      # so it won't be necessary to add to this list.
+      #
+      # The `rescue`s are for the cases where the lexer isn't defined in the current
+      # version.
+      Rouge::Lexers::Lua.builtins rescue nil
+      Rouge::Lexers::PHP.builtins rescue nil
+      Rouge::Lexers::VimL.keywords rescue nil
+      Rouge::Lexers::Gherkin.builtins rescue nil
+      Rouge::Lexers::Matlab.builtins rescue nil
+      Rouge::Lexers::Mathematica.builtins rescue nil
+
       Rouge.const_set(:Rouge, Rouge)
       Object.send(:remove_const, :Rouge)
     end

--- a/lib/loader.rb
+++ b/lib/loader.rb
@@ -33,6 +33,10 @@ class Loader
     end
   end
 
+  def self.latest
+    listing.first
+  end
+
   def self.listing
     path = File.join TMP_DIR, "available_versions"
     if File.exist?(path) && (Time.now - File.mtime(path) <= 86400)
@@ -47,6 +51,8 @@ class Loader
   end
 
   def self.load(id)
+    id = latest if id.nil?
+
     raise UnavailableVersion unless available?(id)
 
     fetch id unless dir?(id)
@@ -66,7 +72,7 @@ class Loader
     $VERBOSE = old_verbose
   end
 
-  def self.version(id)
+  def self.version(id = nil)
     cache[id] ||= load(id)
   end
 end

--- a/lib/message.rb
+++ b/lib/message.rb
@@ -1,0 +1,16 @@
+class Message
+  MSG = {}
+
+  MSG[400] =
+    "<strong>Bad Input</strong>: The input that you submitted is invalid. Please
+    correct it and try again."
+
+  MSG[413] =
+    "<strong>Too Long</strong>: This form accepts a maximum of 1500 characters of text.
+    Please reduce the amount of text and try again."
+
+  def self.[](k)
+    MSG[k]
+  end
+end
+

--- a/lib/message.rb
+++ b/lib/message.rb
@@ -6,8 +6,12 @@ class Message
     correct it and try again."
 
   MSG[413] =
-    "<strong>Too Long</strong>: This form accepts a maximum of 1500 characters of text.
-    Please reduce the amount of text and try again."
+    "<strong>Too Long</strong>: This form accepts a maximum of 1500 characters
+    of text. Please reduce the amount of text and try again."
+
+  MSG[500] =
+    "<strong>Server Error</strong>: A server error occurred while processing
+    your request."
 
   def self.[](k)
     MSG[k]

--- a/test/loader_test.rb
+++ b/test/loader_test.rb
@@ -42,18 +42,6 @@ class LoaderTest < Minitest::Test
     assert_equal "3.15.0", Loader.latest
   end
 
-  def test_listing(ver = "0.0.1")
-    result = Loader.listing
-    assert_equal Array, result.class
-    assert_equal ver, result.last
-  end
-
-  def test_listing_with_file
-    listing_path = File.join Loader::TMP_DIR, "available_versions"
-    File.write listing_path, "0.0.3\n0.0.2"
-    test_listing "0.0.2"
-  end
-
   def test_load_with_valid_id
     rouge = Loader.load "1.1.0"
     assert_equal "1.1.0", rouge.version
@@ -61,5 +49,17 @@ class LoaderTest < Minitest::Test
 
   def test_load_with_invalid_id
     assert_raises(Loader::UnavailableVersion) { Loader.load("0") }
+  end
+
+  def test_versions(ver = "0.0.1")
+    result = Loader.versions
+    assert_equal Array, result.class
+    assert_equal ver, result.last
+  end
+
+  def test_versions_with_file
+    versions_path = File.join Loader::TMP_DIR, "available_versions"
+    File.write versions_path, "0.0.3\n0.0.2"
+    test_versions "0.0.2"
   end
 end

--- a/test/loader_test.rb
+++ b/test/loader_test.rb
@@ -38,6 +38,10 @@ class LoaderTest < Minitest::Test
     assert Dir.exist?(gem_path)
   end
 
+  def test_latest
+    assert_equal "3.15.0", Loader.latest
+  end
+
   def test_listing(ver = "0.0.1")
     result = Loader.listing
     assert_equal Array, result.class

--- a/test/loader_test.rb
+++ b/test/loader_test.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "fileutils"
+
+require_relative "../lib/loader"
+
+class LoaderTest < Minitest::Test
+  def setup
+    Loader.send(:remove_const, :TMP_DIR)
+    Loader.const_set(:TMP_DIR, File.join("test", "data"))
+  end
+
+  def teardown
+    FileUtils.rm_r Dir.glob(File.join(Loader::TMP_DIR, "*"))
+    Loader.instance_variables.each { |ivar| Loader.remove_instance_variable ivar }
+  end
+
+  def test_available?
+    refute Loader.available? "1.0.0"
+    refute Loader.available? "0.1.0"
+  end
+
+  def test_dir
+    assert_equal File.join(Loader::TMP_DIR, "1.1.0"), Loader.dir("1.1.0")
+  end
+
+  def test_dir?
+    refute Loader.dir?("0")
+
+    FileUtils.mkdir File.join(Loader::TMP_DIR, "0")
+    assert Loader.dir?("0")
+  end
+
+  def test_fetch
+    gem_path = File.join(Loader::TMP_DIR, "rouge-1.1.0")
+    Loader.fetch "1.1.0"
+    assert Dir.exist?(gem_path)
+  end
+
+  def test_listing(ver = "0.0.1")
+    result = Loader.listing
+    assert_equal Array, result.class
+    assert_equal ver, result.last
+  end
+
+  def test_listing_with_file
+    listing_path = File.join Loader::TMP_DIR, "available_versions"
+    File.write listing_path, "0.0.3\n0.0.2"
+    test_listing "0.0.2"
+  end
+
+  def test_load_with_valid_id
+    rouge = Loader.load "1.1.0"
+    assert_equal "1.1.0", rouge.version
+  end
+
+  def test_load_with_invalid_id
+    assert_raises(Loader::UnavailableVersion) { Loader.load("0") }
+  end
+end

--- a/views/index.erb
+++ b/views/index.erb
@@ -20,7 +20,8 @@
   </header>
 
   <main>
-    <section class="message" id="flash_message">
+    <section class="message <% if flash %>show<% end %>" id="flash_message">
+      <%= flash %>
     </section>
     <section class="demo">
       <form novalidate="novalidate" class="simple_form parse" action="/parse" accept-charset="UTF-8" data-remote="true" method="post">

--- a/views/index.erb
+++ b/views/index.erb
@@ -20,7 +20,7 @@
   </header>
 
   <main>
-    <section class="message <% if flash %>show<% end %>" id="flash_message">
+    <section class="message<% if flash %> show<% end %>" id="flash_message">
       <%= flash %>
     </section>
     <section class="demo">

--- a/views/index.erb
+++ b/views/index.erb
@@ -36,6 +36,7 @@
         <pre id="parse_result" class="highlight" data-lang="<%= demo.lexer.tag %>"><code><%= demo.result %></code></pre>
         <button id="save_button" name="save">Save this</button>
         <div id="save_message"></div>
+        <input type="hidden" id="parse_version" name="parse[version]" value="v<%= demo.version %>">
       </form>
     </section>
     <section class="key-features">


### PR DESCRIPTION
One of the neat features of the website currently at rouge.jneen.net is the fact that it can dynamically load different versions of Rouge. This PR implements this behaviour in the dingus.

It has the following features:

- **Automatic start-up load**: The latest version of Rouge is automatically loaded when the dingus starts. This keeps the site speedy for most uses.

- **URL-based selection**: The version of Rouge to use is determined by the URL. This means that when a user shares a link to a particular snippet, that URL specifies the version of Rouge. In addition to the benefit of clarity, this also means that a user can check the snippet's source code against different versions of Rouge. Compare [this snippet](https://rouge-dingus-test.herokuapp.com/v3.14.0/jinja/SGVsbG8ge3sgdXNlci5uYW1lfGNhcGl0YWxpemUgfCB1cHBlciB9fSAh) using a version where a bug in the Jinja lexer had not been fixed with [this snippet](https://rouge-dingus-test.herokuapp.com/v3.15.0/jinja/SGVsbG8ge3sgdXNlci5uYW1lfGNhcGl0YWxpemUgfCB1cHBlciB9fSAh) where it had.

- **Patched `load`**: To allow multiple instances of the Rouge library in the same runtime, the constant `Rouge` is removed from the `Object` namespace after the library is loaded. This causes problems for lexers that lazily load content (e.g. keywords). In the earlier implementation, this was fixed by loading that content into the library before removal. This PR adds a method, `Lexer.load`, that sits prior to `Kernel#load` in the ancestor chain. The method temporarily adds the Rouge library back to `Object`, loads the content, and then removes it again.

- **Silent loading**: The Rouge library is loaded with warnings temporarily disabled.

- **Earliest version restriction**: Although the dingus can fetch versions of Rouge prior to v1.1.0, these were unable to load during testing. The dingus will display an error if a version of Rouge prior to v1.1.0 is set in the URL.

These should have been submitted as separate PRs but:

- **Testing infrastructure**: This PR adds some testing infrastructure and there are basic tests written for the `Loader` class.

- **Server-side error messages**: The text of the error messages are moved from the application's JavaScript file to the server-side code. This allows error messages that are displayed via JavaScript in the browser and via server-rendered pages to use the same text.

- **Extraction of `Demo`**: The `Demo` class which was previously included within the file defining the dingus application is now in a separate file in `lib/`.

As with previous PRs, a version of the dingus running this code is available at [rouge-dingus-test.herokuapp.com](https://rouge-dingus-test.herokuapp.com/).