### PR TITLE
Support old pastes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 /.yardoc
 /_yardoc/
 /coverage/
-/db/decrypted.sqlite
+/db/decrypted.db
 /doc/
 /log/
 /pkg/

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
 /.bundle
+/.env
 /.ruby-version
 /.yardoc
 /_yardoc/
 /coverage/
+/db/decrypted.sqlite
 /doc/
 /log/
 /pkg/

--- a/Gemfile
+++ b/Gemfile
@@ -1,12 +1,17 @@
 source 'https://rubygems.org'
 
 # Framework
-gem 'sinatra',  '~>2.0'
+gem 'sinatra', '~>2.0', :require => 'sinatra/base'
 
 # Asset pipeline
 gem 'sassc', '~>2.0'
 gem 'sprockets', '~>4.0'
 gem 'uglifier', '~>4.0'
+
+# Database access
+gem 'hashids', '~>1.0'
+gem 'sequel', '~>5.0'
+gem 'sqlite3', '~>1.0'
 
 # Development and testing
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,9 @@ gem 'sprockets', '~>4.0'
 gem 'uglifier', '~>4.0'
 
 # Database access
+gem 'date', '~>3.0'
 gem 'dotenv', '~>2.0'
+gem 'gdbm', '~>2.0'
 gem 'hashids', '~>1.0'
 gem 'lockbox', '~>0.0'
 

--- a/Gemfile
+++ b/Gemfile
@@ -12,8 +12,6 @@ gem 'uglifier', '~>4.0'
 gem 'dotenv', '~>2.0'
 gem 'hashids', '~>1.0'
 gem 'lockbox', '~>0.0'
-gem 'sequel', '~>5.0'
-gem 'sqlite3', '~>1.0'
 
 # Development and testing
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'sprockets', '~>4.0'
 gem 'uglifier', '~>4.0'
 
 # Database access
+gem 'dotenv', '~>2.0'
 gem 'hashids', '~>1.0'
 gem 'sequel', '~>5.0'
 gem 'sqlite3', '~>1.0'

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'uglifier', '~>4.0'
 # Database access
 gem 'dotenv', '~>2.0'
 gem 'hashids', '~>1.0'
+gem 'lockbox', '~>0.0'
 gem 'sequel', '~>5.0'
 gem 'sqlite3', '~>1.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,9 +2,11 @@ GEM
   remote: https://rubygems.org/
   specs:
     concurrent-ruby (1.1.5)
+    date (3.0.0)
     dotenv (2.7.5)
     execjs (2.7.0)
     ffi (1.12.1)
+    gdbm (2.1.0)
     hashids (1.0.5)
     lockbox (0.3.1)
     m (1.5.1)
@@ -37,7 +39,9 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  date (~> 3.0)
   dotenv (~> 2.0)
+  gdbm (~> 2.0)
   hashids (~> 1.0)
   lockbox (~> 0.0)
   m (~> 1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,7 +21,6 @@ GEM
     ruby2_keywords (0.0.2)
     sassc (2.2.1)
       ffi (~> 1.9)
-    sequel (5.28.0)
     sinatra (2.0.8.1)
       mustermann (~> 1.0)
       rack (~> 2.0)
@@ -30,7 +29,6 @@ GEM
     sprockets (4.0.0)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
-    sqlite3 (1.4.2)
     tilt (2.0.10)
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
@@ -46,10 +44,8 @@ DEPENDENCIES
   minitest (~> 5.0)
   rake (~> 13.0)
   sassc (~> 2.0)
-  sequel (~> 5.0)
   sinatra (~> 2.0)
   sprockets (~> 4.0)
-  sqlite3 (~> 1.0)
   uglifier (~> 4.0)
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,7 @@ GEM
     execjs (2.7.0)
     ffi (1.12.1)
     hashids (1.0.5)
+    lockbox (0.3.1)
     m (1.5.1)
       method_source (>= 0.6.7)
       rake (>= 0.9.2.2)
@@ -40,6 +41,7 @@ PLATFORMS
 DEPENDENCIES
   dotenv (~> 2.0)
   hashids (~> 1.0)
+  lockbox (~> 0.0)
   m (~> 1.0)
   minitest (~> 5.0)
   rake (~> 13.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ GEM
     concurrent-ruby (1.1.5)
     execjs (2.7.0)
     ffi (1.12.1)
+    hashids (1.0.5)
     m (1.5.1)
       method_source (>= 0.6.7)
       rake (>= 0.9.2.2)
@@ -18,6 +19,7 @@ GEM
     ruby2_keywords (0.0.2)
     sassc (2.2.1)
       ffi (~> 1.9)
+    sequel (5.28.0)
     sinatra (2.0.8.1)
       mustermann (~> 1.0)
       rack (~> 2.0)
@@ -26,6 +28,7 @@ GEM
     sprockets (4.0.0)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
+    sqlite3 (1.4.2)
     tilt (2.0.10)
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
@@ -34,12 +37,15 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  hashids (~> 1.0)
   m (~> 1.0)
   minitest (~> 5.0)
   rake (~> 13.0)
   sassc (~> 2.0)
+  sequel (~> 5.0)
   sinatra (~> 2.0)
   sprockets (~> 4.0)
+  sqlite3 (~> 1.0)
   uglifier (~> 4.0)
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     concurrent-ruby (1.1.5)
+    dotenv (2.7.5)
     execjs (2.7.0)
     ffi (1.12.1)
     hashids (1.0.5)
@@ -37,6 +38,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  dotenv (~> 2.0)
   hashids (~> 1.0)
   m (~> 1.0)
   minitest (~> 5.0)

--- a/app.rb
+++ b/app.rb
@@ -37,11 +37,11 @@ class Dingus < Sinatra::Base
     halt 400 unless paste
 
     ver = Loader.latest
-    lang = paste.get(:language)
-    source = paste.get(:source)
+    lang = paste[:language]
+    source = paste[:source]
 
     demo = Demo.new ver, lang, source
-    date = paste.get(:created_at).strftime("%b %e, %Y")
+    date = paste[:created_at].strftime("%b %e, %Y")
     erb :paste, :locals => { :demo => demo, :date => date }
   end
 

--- a/app.rb
+++ b/app.rb
@@ -32,12 +32,9 @@ class Dingus < Sinatra::Base
     erb :index, :locals => { :demo => Demo.new, :flash => flash }
   end
 
-  get '/pastes/:paste' do
-    id = Legacy.hash_to_id params["paste"]
-    puts id
-
-    DB = Sequel.sqlite("legacy.sqlite") unless defined?(DB)
-    paste = DB[:pastes].where(:id => id)
+  get '/pastes/:id' do
+    paste = Legacy.paste params["id"]
+    halt 400 unless paste
 
     ver = Loader.latest
     lang = paste.get(:language)

--- a/assets/stylesheets/application.scss
+++ b/assets/stylesheets/application.scss
@@ -83,7 +83,7 @@ main {
         }
     }
 
-    section.demo {
+    section.demo, section.paste {
         &::after {
             clear: both;
             content: "";
@@ -150,7 +150,14 @@ main {
             overflow-y: scroll;
             padding: 0.5em;
             white-space: pre-wrap;
-            width: 48.82117%;
+
+            @at-root main section.demo pre {
+              width: 48.82117%;
+            }
+
+            @at-root main section.paste pre {
+              width: 100%;
+            }
         }
 
         select {
@@ -185,6 +192,23 @@ main {
             white-space: pre-wrap;
             width: 100%;
         }
+    }
+
+    section.paste {
+      pre {
+      }
+
+      aside {
+        float: right;
+        margin-bottom: -5em;
+        opacity: 0.6;
+        padding: 0.75em 1em 1em 1em;
+        position: relative;
+
+        span {
+          display: block;
+        }
+      }
     }
 
     section.key-features {

--- a/config.ru
+++ b/config.ru
@@ -1,3 +1,4 @@
+require 'dotenv/load'
 require './app'
 
 run Dingus

--- a/lib/legacy.rb
+++ b/lib/legacy.rb
@@ -1,0 +1,17 @@
+require "hashids"
+
+class Legacy
+  class NoID < StandardError; end
+  class NotAHash < StandardError; end
+
+  def self.hash_to_id(h)
+    raise NotAHash unless h.is_a?(String)
+    hashids.decode(h).first
+  end
+
+  def self.hashids()
+    return @hashids if defined?(@hashids)
+    @hashids = Hashids.new ENV['HASHIDS_SALT']
+  end
+end
+

--- a/lib/legacy.rb
+++ b/lib/legacy.rb
@@ -34,7 +34,7 @@ class Legacy
 
     fields = paste.split("\t", 5)
     { :id => fields[0].to_i,
-      :created_at => DateTime.parse(fields[1]), #, "%Y-%m-%d %H:%M:%S.%6N"),
+      :created_at => DateTime.parse(fields[1]),
       :language => fields[3],
       :source => fields[4] }
   end

--- a/lib/legacy.rb
+++ b/lib/legacy.rb
@@ -1,8 +1,19 @@
 require "hashids"
+require "lockbox"
+require "sqlite3"
+require "sequel"
 
 class Legacy
-  class NoID < StandardError; end
   class NotAHash < StandardError; end
+
+  def self.db()
+    return @db if defined?(@db)
+    lockbox = Lockbox.new(key: ENV["LOCKBOX_KEY"])
+    en_path = File.join(__dir__, "..", "db", "encrypted.sqlite")
+    de_path = File.join(__dir__, "..", "db", "decrypted.sqlite")
+    File.binwrite(de_path, lockbox.decrypt(File.binread(en_path)))
+    @db = Sequel.sqlite de_path
+  end
 
   def self.hash_to_id(h)
     raise NotAHash unless h.is_a?(String)
@@ -12,6 +23,11 @@ class Legacy
   def self.hashids()
     return @hashids if defined?(@hashids)
     @hashids = Hashids.new ENV['HASHIDS_SALT']
+  end
+
+  def self.paste(h)
+    paste = db[:pastes].where(:id => hash_to_id(h))
+    (paste.count == 1) ? paste : nil
   end
 end
 

--- a/test/legacy_test.rb
+++ b/test/legacy_test.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "fileutils"
+require "dotenv/load"
+
+require_relative "../lib/legacy"
+
+class LegacyTest < Minitest::Test
+  def setup
+  end
+
+  def teardown
+    Legacy.instance_variables.each { |ivar| Legacy.remove_instance_variable ivar }
+  end
+
+  def test_hash_to_ids_with_valid_hash
+    assert_equal 1, Legacy.hash_to_id("4j")
+  end
+
+  def test_hash_to_ids_with_invalid_hash
+    assert_nil Legacy.hash_to_id("aaa")
+  end
+
+  def test_hash_to_ids_with_not_a_hash
+    assert_raises(Legacy::NotAHash) { Legacy.hash_to_id(4) }
+  end
+end

--- a/test/legacy_test.rb
+++ b/test/legacy_test.rb
@@ -14,12 +14,13 @@ class LegacyTest < Minitest::Test
   end
 
   def test_database_opening
-    assert_equal "Sequel::SQLite::Database", Legacy.db.class.to_s
+    assert_equal "String", Legacy.db.class.to_s
   end
 
   def test_database_successful_retrieval
     res = Legacy.paste "4j"
-    assert_equal 1, res.get(:id)
+    assert_equal 1, res[:id]
+    assert_equal 1428722903, res[:created_at].to_time.to_i
   end
 
   def test_database_unsuccessful_retrieval

--- a/test/legacy_test.rb
+++ b/test/legacy_test.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "minitest/autorun"
-require "fileutils"
 require "dotenv/load"
 
 require_relative "../lib/legacy"
@@ -12,6 +11,20 @@ class LegacyTest < Minitest::Test
 
   def teardown
     Legacy.instance_variables.each { |ivar| Legacy.remove_instance_variable ivar }
+  end
+
+  def test_database_opening
+    assert_equal "Sequel::SQLite::Database", Legacy.db.class.to_s
+  end
+
+  def test_database_successful_retrieval
+    res = Legacy.paste "4j"
+    assert_equal 1, res.get(:id)
+  end
+
+  def test_database_unsuccessful_retrieval
+    res = Legacy.paste "aaa"
+    assert_nil res
   end
 
   def test_hash_to_ids_with_valid_hash

--- a/views/index.erb
+++ b/views/index.erb
@@ -1,73 +1,20 @@
-<html>
-<head>
-  <meta charset="utf-8">
-  <meta name="ROBOTS" content="NOODP">
-  <meta name="viewport" content="width=920">
-  <title>Rouge</title>
-  <link rel="stylesheet" type="text/css" media="all" href="https://necolas.github.io/normalize.css/latest/normalize.css">
-  <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Raleway:800,500|Source+Code+Pro:400,700">
-  <link rel="stylesheet" type="text/css" media="all" href="/assets/application.css">
-  <link rel="author" href="humans.txt">
-  <link rel="shortcut icon" type="image/x-icon" href="/assets/favicon.ico">
-</head>
-<body>
-  <header>
-    <h1 class="main">
-      <a href="/">{ Rouge }</a>
-    </h1>
-    <h2>An elegant, extendable code highlighter written in pure Ruby.</h2>
-    <h4>Available on <a href="https://github.com/rouge-ruby/rouge">GitHub</a></h4>
-  </header>
-
-  <main>
-    <section class="message<% if flash %> show<% end %>" id="flash_message">
-      <%= flash %>
-    </section>
-    <section class="demo">
-      <form novalidate="novalidate" class="simple_form parse" action="/parse" accept-charset="UTF-8" data-remote="true" method="post">
-        <label for="parse_source">Try some code</label>
-        <div class="source">
-          <select name="parse[language]" id="parse_language">
-          <% demo.all_lexers.each do |lexer| %>
-            <option value="<%= lexer.tag %>" <%= "selected" if lexer == demo.lexer %>><%= lexer.title %></option>
-          <% end %>
-          </select>
-          <textarea id="parse_source" name="parse[source]"><%= demo.source %></textarea>
-        </div>
-        <pre id="parse_result" class="highlight" data-lang="<%= demo.lexer.tag %>"><code><%= demo.result %></code></pre>
-        <button id="save_button" name="save">Save this</button>
-        <div id="save_message"></div>
-        <input type="hidden" id="parse_version" name="parse[version]" value="v<%= demo.version %>">
-      </form>
-    </section>
-    <section class="key-features">
-      <ul>
-        <li class="languages">
-          <h3>Plenty of Languages</h3>
-          <article>
-            <p>Rouge supports <%= demo.lexer_count %> languages and counting, including Ruby, JavaScript, Swift, Go, C++, and Haskell. Our <a href="https://github.com/rouge-ruby/rouge/graphs/contributors">contributors</a> are adding more languages all the time.</p>
-          </article>
-        </li>
-        <li class="parsing">
-          <h3>Language Parsing</h3>
-          <article>
-            <p>Rouge aims for the highest quality lexing in all its supported languages, even with strange features and odd corner cases. Try it above and see for yourself!</p>
-          </article>
-        </li>
-        <li class="pygments">
-          <h3>Pygments Compatible</h3>
-          <article>
-            <p>Rouge themes are 100% compatible with <a href="https://pygments.org">Pygments</a>' stylesheets. No need to remake your theme, and no need to spawn a Python process either. Rouge is made in Ruby.</p>
-          </article>
-        </li>
-      </ul>
-    </section>
-  </main>
-
-  <footer>
-    <p>Rouge development by <a href="http://jneen.net">Jeanine Adkisson</a>. Website created by <a href="https://edwardloveall.com">Edward Loveall</a> and <a href="https://inqk.net/">Michael Camilleri</a>.
-    <p>Using Rouge version <%= demo.version %></p>
-  </footer>
-  <script src="/assets/application.js"></script>
-</body>
-</html>
+<section class="message<% if flash %> show<% end %>" id="flash_message">
+  <%= flash %>
+</section>
+<section class="demo">
+  <form novalidate="novalidate" class="simple_form parse" action="/parse" accept-charset="UTF-8" data-remote="true" method="post">
+    <label for="parse_source">Try some code</label>
+    <div class="source">
+      <select name="parse[language]" id="parse_language">
+      <% demo.all_lexers.each do |lexer| %>
+        <option value="<%= lexer.tag %>" <%= "selected" if lexer == demo.lexer %>><%= lexer.title %></option>
+      <% end %>
+      </select>
+      <textarea id="parse_source" name="parse[source]"><%= demo.source %></textarea>
+    </div>
+    <pre id="parse_result" class="highlight" data-lang="<%= demo.lexer.tag %>"><code><%= demo.result %></code></pre>
+    <button id="save_button" name="save">Save this</button>
+    <div id="save_message"></div>
+    <input type="hidden" id="parse_version" name="parse[version]" value="v<%= demo.version %>">
+  </form>
+</section>

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -1,0 +1,54 @@
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="ROBOTS" content="NOODP">
+  <meta name="viewport" content="width=920">
+  <title>Rouge</title>
+  <link rel="stylesheet" type="text/css" media="all" href="https://necolas.github.io/normalize.css/latest/normalize.css">
+  <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Raleway:800,500|Source+Code+Pro:400,700">
+  <link rel="stylesheet" type="text/css" media="all" href="/assets/application.css">
+  <link rel="author" href="humans.txt">
+  <link rel="shortcut icon" type="image/x-icon" href="/assets/favicon.ico">
+</head>
+<body>
+  <header>
+    <h1 class="main">
+      <a href="/">{ Rouge }</a>
+    </h1>
+    <h2>An elegant, extendable code highlighter written in pure Ruby.</h2>
+    <h4>Available on <a href="https://github.com/rouge-ruby/rouge">GitHub</a></h4>
+  </header>
+
+  <main>
+    <%= yield %>
+    <section class="key-features">
+      <ul>
+        <li class="languages">
+          <h3>Plenty of Languages</h3>
+          <article>
+            <p>Rouge supports <%= demo.lexer_count %> languages and counting, including Ruby, JavaScript, Swift, Go, C++, and Haskell. Our <a href="https://github.com/rouge-ruby/rouge/graphs/contributors">contributors</a> are adding more languages all the time.</p>
+          </article>
+        </li>
+        <li class="parsing">
+          <h3>Language Parsing</h3>
+          <article>
+            <p>Rouge aims for the highest quality lexing in all its supported languages, even with strange features and odd corner cases. Try it above and see for yourself!</p>
+          </article>
+        </li>
+        <li class="pygments">
+          <h3>Pygments Compatible</h3>
+          <article>
+            <p>Rouge themes are 100% compatible with <a href="https://pygments.org">Pygments</a>' stylesheets. No need to remake your theme, and no need to spawn a Python process either. Rouge is made in Ruby.</p>
+          </article>
+        </li>
+      </ul>
+    </section>
+  </main>
+
+  <footer>
+    <p>Rouge development by <a href="http://jneen.net">Jeanine Adkisson</a>. Website created by <a href="https://edwardloveall.com">Edward Loveall</a> and <a href="https://inqk.net/">Michael Camilleri</a>.
+    <p>Using Rouge version <%= demo.version %></p>
+  </footer>
+  <script src="/assets/application.js"></script>
+</body>
+</html>

--- a/views/paste.erb
+++ b/views/paste.erb
@@ -1,0 +1,7 @@
+<section class="paste">
+  <aside class="meta">
+    <span class="date"><%= date %></span>
+    <span class="language"><%= demo.lexer.title %></span>
+  </aside>
+  <pre id="parse_result" class="highlight" data-lang="<%= demo.lexer.tag %>"><code><%= demo.result %></code></pre>
+</section>


### PR DESCRIPTION
The website currently at rouge.jneen.net previously allowed users to save snippets of source code that could then be retrieved via a unique URL. Although users can no longer save snippets, the URLs still work and can and are still used (primarily by the maintainers of Rouge as they were often included in bug reports filed on GitHub). If the dingus is to fully replace the current website, it should display these snippets.

The simplest way to achieve this would be to configure the dingus to use a PostgreSQL database. This was not pursued for two reasons:

- First, big, hulking databases are—to use a technical term—gross. Particularly, when they're the metaphorical equivalent of using a hammer to kill a fly. All that this system needs to be able to do is retrieve some strings when given a particular URL. Moreover, these strings will never change and will never increase in number.

- Second, using Postgres complicates development. It is an additional dependency that needs to be installed and set up (made more complicated by the fact that it runs as a service). Once this is done, it remains difficult to test the exact data that is present on Heroku.

Initially, the dingus was developed to use SQLite. This was before the author became aware that the Heroku people have a pathological hatred of SQLite and won't let you use it even though it's like one of the most popular databases in the world and is clearly the right choice in this instance. Desperate to avoid needing to run a Postgres server locally for what is essentially a persistent hashmap, alternatives like DBM and SDB were investigated before [GDBM](https://github.com/ruby/gdbm) was selected.

Additional points:

1. Although no guarantees of privacy were ever given, users who saved snippets may not have appreciated that they could be put in a publicly accessible Git repository one day. To provide some protection, the dingus stores an encrypted version of the GDBM database file. The data is encrypted using [the Lockbox gem](https://github.com/ankane/lockbox).

2. A decrypted version of the database is created on first access and saved to the file system. No checks have been done as to the thread safety of this design.

3. An earlier version of the code in this PR automatically forwarded a user accessing a saved URL to the URL that would have been generated if the snippet were saved using the dingus. This has some advantages but could break if the snippet was over a certain length. A future improvement might be to redirect if the snippet is less than a particular length.

4. To fully use the system locally now requires two environmental variables: (1) a `HASHIDS_SALT` string for use in decoding the URL slugs; and (2) a `LOCKBOX_KEY` string for use in the decryption of the GDBM database file. In development, these can be saved in the root-level file `.env` and will be pulled in by [the dotenv gem](https://github.com/bkeepers/dotenv).

5. The design of the paste page differs slightly from that used on the current website.