### PR TITLE
Improve editing experience

### DIFF
--- a/assets/javascripts/application.js
+++ b/assets/javascripts/application.js
@@ -9,13 +9,13 @@ const tip    = document.getElementById("save_message");
 
 // Submit function
 let submitTimer;
-const submit = function(endpoint, payload) {
+const submit = function(endpoint, payload, overwrite) {
   clearTimeout(submitTimer);
-  submitTimer = setTimeout(update, 500, endpoint, payload);
+  submitTimer = setTimeout(update, 500, endpoint, payload, overwrite);
 };
 
 // Update function
-const update = function(endpoint, payload) {
+const update = function(endpoint, payload, overwrite) {
   let request = new XMLHttpRequest();
 
   request.open("POST", endpoint);
@@ -24,7 +24,7 @@ const update = function(endpoint, payload) {
   request.onreadystatechange = function () {
     if (request.readyState === XMLHttpRequest.DONE && request.status === 200) {
       const data = JSON.parse(request.responseText);
-      source.value = data.source;
+      overwrite ? (source.value = data.source) : null;
       result.innerHTML = "<code>" + data.result + "</code>";
       flash.classList.remove("show");
       flash.innerHTML = "";
@@ -40,22 +40,24 @@ const update = function(endpoint, payload) {
 
 // Reset on language change
 lang.addEventListener("change", function(e) {
-  submit("/parse", { ver: ver.value, lang: lang.value });
+  const payload = { ver: ver.value, lang: lang.value };
+  submit("/parse", payload, true);
   history.pushState({}, "", "/" + encodeURIComponent(ver.value) +
                             "/" + encodeURIComponent(lang.value) +
                             "/");
-});
+}, { capture: false, passive: true });
 
 // Update on source change
 source.addEventListener("input", function(e) {
-  submit("/parse", { ver: ver.value, lang: lang.value, source: source.value });
+  const payload = { ver: ver.value, lang: lang.value, source: source.value };
+  submit("/parse", payload, false);
   let draft_path = "/" + encodeURIComponent(ver.value) +
                    "/" + encodeURIComponent(lang.value) +
                    "/draft";
   if (window.location.pathname !== draft_path) {
     history.pushState({}, "", draft_path);
   }
-});
+}, { capture: false, passive: true });
 
 // Allow encoding of Unicode characters
 const utoa = function(str) {

--- a/assets/javascripts/application.js
+++ b/assets/javascripts/application.js
@@ -1,3 +1,6 @@
+// Global variables
+let editing = false;
+
 // Define elements
 const flash  = document.getElementById("flash_message");
 const lang   = document.getElementById("parse_language");
@@ -40,8 +43,10 @@ const update = function(endpoint, payload, overwrite) {
 
 // Reset on language change
 lang.addEventListener("change", function(e) {
-  const payload = { ver: ver.value, lang: lang.value };
-  submit("/parse", payload, true);
+  (source.value === "") ? (editing = false) : null;
+  const content = editing ? source.value : null;
+  const payload = { ver: ver.value, lang: lang.value, source: content };
+  submit("/parse", payload, !editing);
   history.pushState({}, "", "/" + encodeURIComponent(ver.value) +
                             "/" + encodeURIComponent(lang.value) +
                             "/");
@@ -49,6 +54,7 @@ lang.addEventListener("change", function(e) {
 
 // Update on source change
 source.addEventListener("input", function(e) {
+  editing = true;
   const payload = { ver: ver.value, lang: lang.value, source: source.value };
   submit("/parse", payload, false);
   let draft_path = "/" + encodeURIComponent(ver.value) +

--- a/assets/javascripts/application.js.erb
+++ b/assets/javascripts/application.js.erb
@@ -17,6 +17,12 @@ const submit = function(endpoint, payload, overwrite) {
   submitTimer = setTimeout(update, 500, endpoint, payload, overwrite);
 };
 
+// Clear flash message
+const clear_message = function() {
+  flash.classList.remove("show");
+  flash.innerHTML = "";
+};
+
 // Update function
 const update = function(endpoint, payload, overwrite) {
   let request = new XMLHttpRequest();
@@ -26,11 +32,11 @@ const update = function(endpoint, payload, overwrite) {
 
   request.onreadystatechange = function () {
     if (request.readyState === XMLHttpRequest.DONE && request.status === 200) {
+      clear_message();
       const data = JSON.parse(request.responseText);
       overwrite ? (source.value = data.source) : null;
+      result.dataset.lang = payload.lang;
       result.innerHTML = "<code>" + data.result + "</code>";
-      flash.classList.remove("show");
-      flash.innerHTML = "";
     } else if (request.readyState === XMLHttpRequest.DONE && request.status !== 200) {
       const data = JSON.parse(request.responseText);
       flash.innerHTML = data.message;
@@ -63,12 +69,36 @@ source.addEventListener("input", function(e) {
   if (window.location.pathname !== draft_path) {
     history.pushState({}, "", draft_path);
   }
+  if (source.value.length > <%= Dingus::MAX_BODY_SIZE %>) {
+    save.disabled = true;
+    save.classList.add("disabled");
+  } else {
+    save.disabled = false;
+    save.classList.remove("disabled");
+  }
 }, { capture: false, passive: true });
+
+const error_message = function(code) {
+  let request = new XMLHttpRequest();
+
+  request.open("GET", "/message/" + code);
+  request.setRequestHeader("Content-Type", "application/json");
+
+  request.onreadystatechange = function () {
+    if (request.readyState === XMLHttpRequest.DONE && request.status === 200) {
+      const data = JSON.parse(request.responseText);
+      flash.innerHTML = data.message;
+      flash.classList.add("show");
+    }
+  };
+
+  request.send();
+};
 
 // Allow encoding of Unicode characters
 const utoa = function(str) {
   return window.btoa(unescape(encodeURIComponent(str))).replace(/=+$/, "");
-}
+};
 
 // Copy to clipboard
 const copyToClipboard = function(text) {
@@ -90,16 +120,21 @@ const copyToClipboard = function(text) {
       document.body.removeChild(textarea);
     }
   }
-}
+};
 
 // Save the snippet
 save.addEventListener("click", function(e) {
   e.preventDefault();
-  let save_path = "/" + encodeURIComponent(ver.value) +
-                  "/" + encodeURIComponent(lang.value) +
-                  "/" + utoa(source.value);
-  history.pushState({}, "", save_path);
-  copyToClipboard(window.location);
-  tip.innerHTML = "Link to snippet copied!";
-  tip.style.display = "inline-block";
-});
+  if (source.value.length > <%= Dingus::MAX_BODY_SIZE %>) {
+    error_message(413);
+  } else {
+    clear_message();
+    let save_path = "/" + encodeURIComponent(ver.value) +
+                    "/" + encodeURIComponent(lang.value) +
+                    "/" + utoa(source.value);
+    history.pushState({}, "", save_path);
+    copyToClipboard(window.location);
+    tip.innerHTML = "Link to snippet copied!";
+    tip.style.display = "inline-block";
+  }
+}, { capture: false, passive: false });

--- a/assets/javascripts/application.js.erb
+++ b/assets/javascripts/application.js.erb
@@ -7,6 +7,7 @@ const lang   = document.getElementById("parse_language");
 const source = document.getElementById("parse_source");
 const ver    = document.getElementById("parse_version");
 const result = document.getElementById("parse_result");
+const code   = document.getElementById("parse_code");
 const save   = document.getElementById("save_button");
 const tip    = document.getElementById("save_message");
 
@@ -36,7 +37,8 @@ const update = function(endpoint, payload, overwrite) {
       const data = JSON.parse(request.responseText);
       overwrite ? (source.value = data.source) : null;
       result.dataset.lang = payload.lang;
-      result.innerHTML = "<code>" + data.result + "</code>";
+      code.innerHTML = data.result;
+      code.scrollIntoView(false);
     } else if (request.readyState === XMLHttpRequest.DONE && request.status !== 200) {
       const data = JSON.parse(request.responseText);
       flash.innerHTML = data.message;

--- a/assets/javascripts/application.js.erb
+++ b/assets/javascripts/application.js.erb
@@ -24,6 +24,24 @@ const clear_message = function() {
   flash.innerHTML = "";
 };
 
+// Get an error message
+const error_message = function(code) {
+  let request = new XMLHttpRequest();
+
+  request.open("GET", "/message/" + code);
+  request.setRequestHeader("Content-Type", "application/json");
+
+  request.onreadystatechange = function () {
+    if (request.readyState === XMLHttpRequest.DONE && request.status === 200) {
+      const data = JSON.parse(request.responseText);
+      flash.innerHTML = data.message;
+      flash.classList.add("show");
+    }
+  };
+
+  request.send();
+};
+
 // Update function
 const update = function(endpoint, payload, overwrite) {
   let request = new XMLHttpRequest();
@@ -80,22 +98,10 @@ source.addEventListener("input", function(e) {
   }
 }, { capture: false, passive: true });
 
-const error_message = function(code) {
-  let request = new XMLHttpRequest();
-
-  request.open("GET", "/message/" + code);
-  request.setRequestHeader("Content-Type", "application/json");
-
-  request.onreadystatechange = function () {
-    if (request.readyState === XMLHttpRequest.DONE && request.status === 200) {
-      const data = JSON.parse(request.responseText);
-      flash.innerHTML = data.message;
-      flash.classList.add("show");
-    }
-  };
-
-  request.send();
-};
+// Scroll the highlighted window
+source.addEventListener("scroll", function(e) {
+  result.scrollTop = source.scrollTop;
+}, { capture: false, passive: true });
 
 // Allow encoding of Unicode characters
 const utoa = function(str) {

--- a/assets/stylesheets/application.scss
+++ b/assets/stylesheets/application.scss
@@ -122,6 +122,12 @@ main {
             text-decoration: none;
             vertical-align: middle;
             white-space: nowrap;
+
+            &.disabled {
+              background-color: #e2e8f0;
+              border: 1px solid #cbd5e0;
+              cursor: not-allowed;
+            }
         }
 
         form {

--- a/lib/demo.rb
+++ b/lib/demo.rb
@@ -1,4 +1,6 @@
 class Demo
+  class InvalidVersion < StandardError; end
+
   attr_reader :rouge, :lexer, :source
 
   def initialize(ver = :latest, lang = nil, source = nil)
@@ -24,9 +26,11 @@ class Demo
   end
 
   private def set_version(ver)
-    ver = (ver.is_a?(String) && ver[0] == "v") ? ver.slice(1..-1) : :latest
+    return Loader.get(ver) if ver == :latest
 
-    Loader.get ver
+    raise InvalidVersion unless ver.is_a?(String) && ver[0] == "v"
+
+    Loader.get ver.slice(1..-1)
   end
 
   private def set_lexer(lang)

--- a/lib/message.rb
+++ b/lib/message.rb
@@ -5,9 +5,17 @@ class Message
     "<strong>Bad Input</strong>: The input that you submitted is invalid. Please
     correct it and try again."
 
+  MSG[404] =
+    "<strong>Not Found</strong>: No resource was found that matched your
+    request. Please correct the URL and try again."
+
   MSG[413] =
-    "<strong>Too Long</strong>: This form accepts a maximum of 1500 characters
-    of text. Please reduce the amount of text and try again."
+    "<strong>Too Long</strong>: The amount of text you have entered exceeds the
+    maximum length we accept. Please reduce the amount of text and try again."
+
+  MSG[414] =
+    "<strong>Bad URL</strong>: The URL you have requested is too long. Please
+    reduce the length and try again."
 
   MSG[500] =
     "<strong>Server Error</strong>: A server error occurred while processing

--- a/views/index.erb
+++ b/views/index.erb
@@ -12,7 +12,7 @@
       </select>
       <textarea id="parse_source" name="parse[source]"><%= demo.source %></textarea>
     </div>
-    <pre id="parse_result" class="highlight" data-lang="<%= demo.lexer.tag %>"><code><%= demo.result %></code></pre>
+    <pre id="parse_result" class="highlight" data-lang="<%= demo.lexer.tag %>"><code id="parse_code"><%= demo.result %></code></pre>
     <button id="save_button" name="save">Save this</button>
     <div id="save_message"></div>
     <input type="hidden" id="parse_version" name="parse[version]" value="v<%= demo.version %>">


### PR DESCRIPTION
This PR improves the JavaScript code used in the dingus in four ways.

First, the dingus will no longer overwrite the content of the `textarea` element as a user is typing. In previous versions, the value of the `textarea` would be overwritten whenever content was received from the server. As a user typed, the JavaScript in the client would be sending and receiving highlighted text and so there was always a risk that what was received from the server was now 'behind' what the user had typed. Indeed, given that the dingus rate limits what it sends to the server, a fast typist would almost certainly see characters 'disappear'. The dingus now leaves the content of the `textarea` alone.

Second, the dingus will no longer overwrite the content of the `textarea` element if the user has typed text. In previous versions, swapping the highlighting language would cause the value of the `textarea` to be replaced by the demo text for that language. That now only happens if the text in the `textarea` has not been edited or is blank.

Third, error handling has been improved. There are now centralised settings for the maximum URL path and body content sizes that are referred to from both the Ruby and JavaScript code. Error messages are similarly centralised. Finally, there is visual feedback provided by disabling the save button when the length of the user's text exceeds the maximum length.

Fourth, the highlighted code now scrolls in tandem with the `textarea`. This works both as the user types new code but also if the user scrolls the `textarea`.