### PR TITLE
Fix editor behaviour

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -46,19 +46,6 @@ class Dingus < Sinatra::Base
     { :message => Message[params["code"].to_i] }.to_json
   end
 
-  get '/pastes/:id' do
-    paste = Legacy.paste params["id"]
-    halt 400 unless paste
-
-    ver = "v" + Loader.latest
-    lang = paste[:language]
-    source = paste[:source]
-
-    demo = Demo.new ver, lang, source
-    date = paste[:created_at].strftime("%b %e, %Y")
-    erb :paste, :locals => { :demo => demo, :date => date }
-  end
-
   post '/parse' do
     case request.content_type
     when "application/json"
@@ -81,6 +68,19 @@ class Dingus < Sinatra::Base
       source = Base64.urlsafe_encode64 source, padding: false
       redirect to("/" + ver + "/" + lang + "/" + source)
     end
+  end
+
+  get '/pastes/:id' do
+    paste = Legacy.paste params["id"]
+    halt 400 unless paste
+
+    ver = "v" + Loader.latest
+    lang = paste[:language]
+    source = paste[:source]
+
+    demo = Demo.new ver, lang, source
+    date = paste[:created_at].strftime("%b %e, %Y")
+    erb :paste, :locals => { :demo => demo, :date => date }
   end
 
   get '/:ver/:lang/:source?' do

--- a/app.rb
+++ b/app.rb
@@ -87,7 +87,7 @@ class Dingus < Sinatra::Base
     if params["source"].nil? || params["source"] == "draft"
       demo = Demo.new params["ver"], params["lang"] rescue halt 400
     else
-      source = Base64.urlsafe_decode64 params["source"]
+      source = Base64.urlsafe_decode64(params["source"]).force_encoding("utf-8")
       demo = Demo.new params["ver"], params["lang"], source rescue halt 400
     end
 

--- a/assets/javascripts/application.js.erb
+++ b/assets/javascripts/application.js.erb
@@ -56,9 +56,9 @@ const update = function(endpoint, payload, overwrite) {
       clear_message();
       const data = JSON.parse(request.responseText);
       overwrite ? (source.value = data.source) : null;
-      result.dataset.lang = payload.lang;
       code.innerHTML = data.result;
-      code.scrollIntoView(false);
+      result.dataset.lang = payload.lang;
+      result.scrollTop = source.scrollTop;
     } else if (request.readyState === XMLHttpRequest.DONE && request.status !== 200) {
       const data = JSON.parse(request.responseText);
       flash.innerHTML = data.message;

--- a/assets/javascripts/application.js.erb
+++ b/assets/javascripts/application.js.erb
@@ -106,8 +106,18 @@ source.addEventListener("scroll", function(e) {
 }, { capture: false, passive: true });
 
 // Allow encoding of Unicode characters
-const utoa = function(str) {
-  return window.btoa(unescape(encodeURIComponent(str))).replace(/=+$/, "");
+const urlsafe_utoa = function(str) {
+  // return window.btoa(unescape(encodeURIComponent(str))).replace(/=+$/, "");
+  comp = encodeURIComponent(str);
+  unescaped_comp = unescape(comp);
+  encoded_comp = window.btoa(unescaped_comp);
+  return encoded_comp.replace(/[+/=]/g, function(match, offset, string) {
+    switch (match) {
+      case "+": return "-";
+      case "/": return "_";
+      case "=": return "";
+    }
+  });
 };
 
 // Copy to clipboard
@@ -141,7 +151,7 @@ save.addEventListener("click", function(e) {
     clear_message();
     let save_path = "/" + encodeURIComponent(ver.value) +
                     "/" + encodeURIComponent(lang.value) +
-                    "/" + utoa(source.value);
+                    "/" + urlsafe_utoa(source.value);
     history.pushState({}, "", save_path);
     copyToClipboard(window.location);
     tip.innerHTML = "Link to snippet copied!";

--- a/assets/javascripts/application.js.erb
+++ b/assets/javascripts/application.js.erb
@@ -84,7 +84,7 @@ lang.addEventListener("change", function(e) {
 source.addEventListener("input", function(e) {
   editing = true;
   const payload = { ver: ver.value, lang: lang.value, source: source.value };
-  submit("/parse", payload, false);
+  submit("/parse", payload, !editing);
   let draft_path = "/" + encodeURIComponent(ver.value) +
                    "/" + encodeURIComponent(lang.value) +
                    "/draft";

--- a/assets/javascripts/application.js.erb
+++ b/assets/javascripts/application.js.erb
@@ -22,6 +22,8 @@ const submit = function(endpoint, payload, overwrite) {
 const clear_message = function() {
   flash.classList.remove("show");
   flash.innerHTML = "";
+  tip.classList.remove("show");
+  tip.innerHTML = "";
 };
 
 // Get an error message
@@ -143,6 +145,6 @@ save.addEventListener("click", function(e) {
     history.pushState({}, "", save_path);
     copyToClipboard(window.location);
     tip.innerHTML = "Link to snippet copied!";
-    tip.style.display = "inline-block";
+    tip.classList.add("show");
   }
 }, { capture: false, passive: false });

--- a/assets/stylesheets/application.scss
+++ b/assets/stylesheets/application.scss
@@ -97,6 +97,10 @@ main {
             margin-left: 2em;
             padding: 0.5em 1em;
             vertical-align: middle;
+
+            &.show {
+              display: inline-block;
+            }
         }
 
         .source {


### PR DESCRIPTION
This PR fixes a few things:

1. the scroll position of the highlighted window becoming out of sync with the scroll position of the source window (fixes #8);
2. the base 64 encoded URL component containing the character `/` and breaking the route matching; and
3. the 'link copied' message not hiding after another action being taken.

In addition, I tidied up some minor semantic issues. I realise this should have been done through separate PRs but I'm a crazy man (you can't stop me).